### PR TITLE
Log seeds, closes #44

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/Specifier.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/Specifier.java
@@ -187,4 +187,12 @@ public class Specifier implements Description {
         return suiteName;
     }
 
+    private SourceGenerator getSourceGenerator() {
+        return sourceGenerator;
+    }
+
+    public long getSeed() {
+        return getSourceGenerator().getSeed();
+    }
+
 }

--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/PairBuilder.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/PairBuilder.java
@@ -55,6 +55,7 @@ public final class PairBuilder<F, S> implements TwoColumns<F,S> {
             if (description.equals(descriptionFormat)) {
                 description += String.format("(%s, %s)", row.first, row.second);
             }
+            description += " (seed: " + specifier.getSeed() + ")";
             specifier.specifyBehaviour(String.valueOf(i) + ": " + description, row.first, row.second, specification);
         }
         return this;

--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/TripletBuilder.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/TripletBuilder.java
@@ -56,6 +56,7 @@ public final class TripletBuilder<F, S, T> implements ThreeColumns<F,S,T> {
             if (description.equals(descriptionFormat)) {
                 description += String.format("(%s, %s, %s)", row.first, row.second, row.third);
             }
+            description += " (seed: " + specifier.getSeed() + ")";
             specifier.specifyBehaviour(String.valueOf(i) + ": " + description, row.first, row.second, row.third, specification);
         }
         return this;

--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/ValueBuilder.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/ValueBuilder.java
@@ -37,6 +37,7 @@ public final class ValueBuilder<T> implements Column<T> {
             if (description.equals(descriptionFormat)) {
                 description += String.format("(%s)", value);
             }
+            description += " (seed: " + specifier.getSeed() + ")";
             specifier.specifyBehaviour(String.valueOf(i) + ": " + description, value, specification);
         }
         return this;


### PR DESCRIPTION
This adds seeds to the description in the `toShow` method of each specification.

The seed is appended after the columns.
