### PR TITLE
usesTable fluent table builder

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/Specifier.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/Specifier.java
@@ -8,14 +8,19 @@ import com.insightfullogic.lambdabehave.generators.SourceGenerator;
 import com.insightfullogic.lambdabehave.impl.generators.GeneratedDescriptionBuilder;
 import com.insightfullogic.lambdabehave.impl.reports.Report;
 import com.insightfullogic.lambdabehave.impl.specifications.PairBuilder;
+import com.insightfullogic.lambdabehave.impl.specifications.TitledTable;
 import com.insightfullogic.lambdabehave.impl.specifications.TripletBuilder;
 import com.insightfullogic.lambdabehave.impl.specifications.ValueBuilder;
 import com.insightfullogic.lambdabehave.specifications.*;
 import org.mockito.Mockito;
+import org.mockito.cglib.proxy.Enhancer;
+import org.mockito.cglib.proxy.MethodInterceptor;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -90,6 +95,17 @@ public class Specifier implements Description {
     @Override
     public <T> Column<T> uses(Stream<T> values) {
         return uses(values.collect(toList()));
+    }
+
+    public <T, F, S> TitledTable<T, F, S> usesTable(Class<T> clazz, Function<T, F> first, Function<T, S> second) {
+        List<Method> m = new ArrayList<>();
+        final T mock = (T) Enhancer.create(clazz, (MethodInterceptor) (o, method, objects, methodProxy) -> {
+            m.add(method);
+            return null;
+        });
+        first.apply(mock);
+        second.apply(mock);
+        return new TitledTable<>(m, this, clazz);
     }
 
     @Override

--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/TitledTable.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/specifications/TitledTable.java
@@ -1,0 +1,47 @@
+package com.insightfullogic.lambdabehave.impl.specifications;
+
+import com.insightfullogic.lambdabehave.impl.Specifier;
+import com.insightfullogic.lambdabehave.specifications.ColumnDataSpecification;
+import org.mockito.cglib.proxy.Enhancer;
+import org.mockito.cglib.proxy.MethodInterceptor;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class TitledTable<T, F, S> {
+    private final List<Method> methods;
+    private final Specifier specifier;
+    private final Class clazz;
+
+    private final List<F> firsts = new ArrayList<>();
+    private final List<S> seconds = new ArrayList<>();
+
+    public TitledTable(List<Method> methods, Specifier specifier, Class clazz) {
+        this.methods = methods;
+        this.specifier = specifier;
+        this.clazz = clazz;
+    }
+
+    public TitledTable<T, F, S> toShow(String description, ColumnDataSpecification<T> specification) {
+        final Iterator<F> fit = firsts.iterator();
+        final Iterator<S> sit = seconds.iterator();
+        while (fit.hasNext()) {
+            Object[] values = new Object[]{fit.next(), sit.next()};
+            final T mock = (T) Enhancer.create(clazz, (MethodInterceptor) (o, method, objects, methodProxy) -> values[methods.indexOf(method)]);
+            final String describe = String.format(description,
+                    values[0], values[1],
+                    methods.get(0).getName(), methods.get(1).getName());
+            specifier.specifyBehaviour(describe, mock, specification);
+        }
+        return this;
+    }
+
+    public TitledTable<T, F, S> withRow(F first, S second) {
+        firsts.add(first);
+        seconds.add(second);
+        return this;
+    }
+}

--- a/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/example/DataDrivenConstructorSpec.java
+++ b/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/example/DataDrivenConstructorSpec.java
@@ -1,0 +1,27 @@
+package com.insightfullogic.lambdabehave.example;
+
+import com.insightfullogic.lambdabehave.JunitSuiteRunner;
+import com.insightfullogic.lambdabehave.impl.Specifier;
+import org.junit.runner.RunWith;
+
+import static com.insightfullogic.lambdabehave.Suite.describe;
+
+interface Item {
+    int value();
+    boolean isOverTwo();
+}
+
+@RunWith(JunitSuiteRunner.class)
+public class DataDrivenConstructorSpec {{
+
+    describe("a number", it -> {
+        // TODO not yet part of the public interface
+        ((Specifier) it).usesTable(Item.class, Item::value, Item::isOverTwo)
+                .withRow(2, false)
+                .withRow(3, true)
+                .withRow(1, false)
+            .toShow("%d is greater than two? %s", (expect, row) -> {
+                expect.that(row.value() > 2).is(row.isOverTwo());
+            });
+    });
+}}


### PR DESCRIPTION
Moving towards having typed tables:

```
interface Item {
    int value();
    boolean isOverTwo();
}

// ...

it.usesTable(Item.class, Item::value, Item::isOverTwo)
        .withRow(2, false)
        .withRow(3, true)
        .withRow(1, false)
    .toShow("%d is greater than two? %s", (expect, row) -> {
        expect.that(row.value() > 2).is(row.isOverTwo());
    });
```

Bad but not awful `Enhancer` under the hood, which Mockito already depends upon.
