### PR TITLE
Add possibility to match message of expected Exception (issue #53)

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/Expect.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/Expect.java
@@ -35,7 +35,7 @@ public final class Expect {
         return new ArrayExpectation<>(array, true);
     }
 
-    public void exception(final Class<? extends Throwable> expectedException, final Block block) throws Exception {
+    public BoundExpectation<? extends Throwable> exception(final Class<? extends Throwable> expectedException, final Block block) throws Exception {
         String expectedName = expectedException.getName();
         try {
             block.run();
@@ -44,9 +44,10 @@ public final class Expect {
                 String name = throwable.getClass().getName();
                 failure("Expected exception: " + expectedName + ", but " + name + " was thrown");
             }
-            return;
+            return new BoundExpectation<>(throwable, true);
         }
         failure("Expected exception: " + expectedName + ", but no exception was thrown");
+        return null;
     }
 
     // NB: no failure without a message because its a bad idea to not have test failure diagnostics

--- a/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/ExceptionSpec.java
+++ b/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/ExceptionSpec.java
@@ -57,12 +57,18 @@ public class ExceptionSpec {{
             AssertionError wrongException = new AssertionError(
                 "Expected exception: java.lang.RuntimeException, but java.lang.Exception was thrown");
 
+            AssertionError wrongExceptionMessage = new AssertionError("\n" +
+                    "Expected: hasProperty(\"message\", is \"different message\")\n" +
+                    "     but: property 'message' was \"exception message\"");
+
             expect.that(specifications)
                 .hasItem(success("pass if exceptions thrown are expected"))
                 .hasItem(failure("fail if exceptions are expected but not thrown", noException))
                 .hasItem(success("pass if an AssertionError is expected"))
                 .hasItem(success("pass if exceptions of a sub class are expected"))
-                .hasItem(failure("fail if exceptions of a different type are expected", wrongException));
+                .hasItem(failure("fail if exceptions of a different type are expected", wrongException))
+                .hasItem(success("pass if exception message is the same as expected"))
+                .hasItem(failure("fail if exception message is different than expected", wrongExceptionMessage));
         });
 
         it.should("support expect.exception being used in data driven testing", expect -> {

--- a/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/testcases/exceptions/ExceptionHandling.java
+++ b/lambda-behave/src/test/java/com/insightfullogic/lambdabehave/testcases/exceptions/ExceptionHandling.java
@@ -1,6 +1,7 @@
 package com.insightfullogic.lambdabehave.testcases.exceptions;
 
 import static com.insightfullogic.lambdabehave.Suite.describe;
+import static org.hamcrest.Matchers.is;
 
 public class ExceptionHandling {{
     describe("a suite full of exceptions", it -> {
@@ -32,6 +33,18 @@ public class ExceptionHandling {{
             expect.exception(RuntimeException.class, () -> {
                 throw new Exception();
             });
+        });
+
+        it.should("pass if exception message is the same as expected", expect -> {
+            expect.exception(Exception.class, () -> {
+                throw new Exception("exception message");
+            }).hasProperty("message", is("exception message"));
+        });
+
+        it.should("fail if exception message is different than expected", expect -> {
+            expect.exception(Exception.class, () -> {
+                throw new Exception("exception message");
+            }).hasProperty("message", is("different message"));
         });
     });
 }}


### PR DESCRIPTION
Change witch add possibility to match properties of exception. 

Example:

``` java
expect.exception(Exception.class, () -> {
    // (... some code)
    throw new Exception("expected message");
    // (... some code)
}).hasProperty("message", is("expected message"));
```
