### PR TITLE
Add method to check if a string matches a regular expression

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/StringExpectation.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/StringExpectation.java
@@ -48,7 +48,7 @@ public final class StringExpectation extends BoundExpectation<String> {
     }
 
     public StringExpectation matches(String regex) {
-        assertTrue(objectUnderTest.matches(regex));
+        assertTrue("String " + objectUnderTest + " does not match regex " + regex, objectUnderTest.matches(regex));
         return this;
     }
 


### PR DESCRIPTION
This PR adds a method to the `StringExpectation` class to test whether a `String` matches a given regular expression.
