### PR TITLE
Added .has syntatic sugar to BoundExpectations 

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/BoundExpectation.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/expectations/BoundExpectation.java
@@ -72,6 +72,10 @@ public class BoundExpectation<T> {
         return matches(matcher);
     }
 
+    public BoundExpectation<T> has(final Matcher<? super T> matcher) {
+        return is(matcher);
+    }
+
     public BoundExpectation<T> is(final T value) {
         return matches(Matchers.is(value));
     }


### PR DESCRIPTION
i like to use FeatureMatcher's to extract data in tests for duplication removal, so given the following:

``` java
expect.that(item).hasProperty("foo", equalTo("bar"));
```

As soon as this appears twice I will convert it to

``` java
expect.that(item).is(foo(equalTo("bar")));
```

Where `foo` is a standard Hamcrest FeatureMatcher

With lambda-behave this doesn't read as nice and would prefer a `has` method, so the following would be what I write:

``` java
expect.that(item).has(foo(equalTo("bar")));
```

This is a simple pass through to `is` in BoundExpectations
