### PR TITLE
Don't hide assertion stack trace when reporting test failures

### DIFF
--- a/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/AbstractSuiteRunner.java
+++ b/lambda-behave/src/main/java/com/insightfullogic/lambdabehave/impl/AbstractSuiteRunner.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.insightfullogic.lambdabehave.SpecificationError;
-import com.insightfullogic.lambdabehave.TestFailure;
 import com.insightfullogic.lambdabehave.impl.reports.SpecificationReport;
 
 public abstract class AbstractSuiteRunner extends ParentRunner<CompleteBehaviour> {
@@ -61,7 +60,7 @@ public abstract class AbstractSuiteRunner extends ParentRunner<CompleteBehaviour
                 notifier.fireTestFinished(test);
                 return;
             case FAILURE:
-                notifier.fireTestFailure(new Failure(test, new TestFailure(spec.getMessage())));
+                notifier.fireTestFailure(new Failure(test, spec.getCause()));
                 return;
             case ERROR:
             default:


### PR DESCRIPTION
In the released 0.4 version, all assertion failures come with a stacktrace that starts at `AbstractSuiteRunner:63`, since that's where a `TestFailure` is `new`-ed up, which is an `Exception` subclass that is reported as the error.

By reporing `spec.getCause()` instead, we get the real line number in the test where the actual assertion is, which is much more valuable.